### PR TITLE
Fixed hunter catching player issue + implemented dijkstra 

### DIFF
--- a/Hunter.py
+++ b/Hunter.py
@@ -59,7 +59,7 @@ class Hunter(NPC):
         # Get distance between Hunter and Player
         dist = self._current_position.distance(player.get_current_position())
 
-        if dist == 1:
+        if -2 <= dist <= 1.5:
             # Hunter is 1 tile away → Trigger Game Over
             messages.append(EmoteMessage(self, player, 'exclamation', emote_pos=self._current_position))
             messages.append(DialogueMessage(self, player, "GAME OVER! The hunter caught you.", self.get_image_name()))

--- a/MovementStrategy.py
+++ b/MovementStrategy.py
@@ -5,6 +5,7 @@ from .imports import *
 from typing import TYPE_CHECKING
 if TYPE_CHECKING:
     from coord import Coord
+from heapq import *
 
 class MovementStrategy(ABC):
     """Defines how the Hunter should move"""
@@ -22,7 +23,69 @@ class RandomMovement(MovementStrategy):
 
 class ShortestPathMovement(MovementStrategy):
     def move(self, hunter, direction: str, player = None) -> list:
+        # Direction mappings
+        direc_map = {
+            'up': (-1, 0),
+            'down': (1, 0),
+            'left': (0, -1),
+            'right': (0, 1)
+        }
+        direc_map_inverse = {
+            (-1, 0): 'up',
+            (1, 0): 'down',
+            (0, -1): 'left',
+            (0, 1): 'right'}
+
+        def distance(pos1, pos2):
+            """Calculate Manhattan distance between two positions."""
+            return abs(pos1[0] - pos2[0]) + abs(pos1[1] - pos2[1]) 
+
         # Use the given direction (computed via hunter.get_direction_toward)
+        hunter_pos: Coord = hunter.get_current_position()
+        player_pos: Coord = player.get_current_position()
+        room = hunter.get_current_room()
+
+        prev_map = {}
+
+        pq = [(0, (hunter_pos.y, hunter_pos.x))]
+        visited = set()
+        
+        def is_tree_at_Coord(coord):
+            """Check if a Tree object exists at the given coordinate."""
+            obj_list = room.get_map_objects_at(coord)
+            for obj in obj_list:
+                if str(type(obj)) == "<class 'C303-project.example_map.Tree'>":
+                    return True
+            return False
+        
+        # Dijkstra's algorithm        
+        while pq:
+            dist, pos = heappop(pq)
+            if pos in visited or is_tree_at_Coord(Coord(pos[0], pos[1])):
+                continue
+            visited.add(pos)
+            if pos == (player_pos.y, player_pos.x):
+                break
+            for direction, (dy, dx) in direc_map.items():
+                new_pos = (pos[0] + dy, pos[1] + dx)
+                # Boundary check
+                if 0 <= new_pos[0] < 15 and 0 <= new_pos[1] < 15:
+                    heappush(pq, (distance(new_pos, (player_pos.y, player_pos.x)), new_pos))
+                    if new_pos not in prev_map:
+                        prev_map[new_pos] = pos
+        
+        # Backtrack to find the path
+        pos = (player_pos.y, player_pos.x)
+        while pos in prev_map:
+            if prev_map[pos] == (hunter_pos.y, hunter_pos.x):
+                break
+            else:
+                pos = prev_map[pos]
+        # Determine the direction to move
+        delta_pos = (pos[0] - hunter_pos.y, pos[1] - hunter_pos.x)
+        if delta_pos in direc_map_inverse:
+            direction = direc_map_inverse[delta_pos]
+                
         print(f"ShortestPathMovement: moving {direction}!")
         return hunter.base_move(direction)
     
@@ -36,7 +99,7 @@ class TeleportMovement(MovementStrategy):
         room = hunter.get_current_room()
         now = time.time()
 
-        if now - self.last_teleport_time >= 1:
+        if now - self.last_teleport_time >= 2:
             self.last_teleport_time = now
 
             hunter_pos = hunter.get_current_position()
@@ -51,7 +114,13 @@ class TeleportMovement(MovementStrategy):
 
             #teleports 2 tiles away
             #teleport_target = Coord(player_pos.y - 2 * dy, player_pos.x - 2 * dx) 
-            teleport_target = Coord(player_pos.y, player_pos.x)
+
+            distance = abs(dx) + abs(dy)
+            if distance <= 1:
+                teleport_target = player_pos  # teleport ONTO player if one tile away (in case the player isnt moving)
+            else:
+                teleport_target = Coord(player_pos.y - dy, player_pos.x - dx)  # 1 tile away
+
             print(f"Teleporting to: {teleport_target}")
             
             status, err = room.remove_from_grid(hunter, hunter.get_current_position())


### PR DESCRIPTION
For hunter catching player: 
- Adjusted the distance for when the hunter catches the player.
- Fixed small teleport logic: If the player doesn't move and the hunter is already one tile away, the hunter will now move onto the player's position. (before the change, the hunter was not moving because it was already one tile away)

For the shortest path move: 
- implement dijkstra. the hunter can avoid trees to find the shortest path to the player. 